### PR TITLE
fix: make constant.other.equalsignliteral.arm64 pattern more strict

### DIFF
--- a/syntaxes/arm64.tmLanguage.json
+++ b/syntaxes/arm64.tmLanguage.json
@@ -56,7 +56,7 @@
 		},
 		{
 			"name": "constant.other.equalsignliteral.arm64",
-			"match": "=.*"
+			"match": "=.*?(?=//|$)"
 		},
 		{
 			"name": "variable.parameter.conditioncode.arm64",


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/5b751585-77ba-4d95-ac8a-6f62329260a3)

After:

![image](https://github.com/user-attachments/assets/5dbefee9-ad97-44df-9526-abbd501c043f)
